### PR TITLE
iosSimulatorArm64 support

### DIFF
--- a/sample/ios-app/Podfile.lock
+++ b/sample/ios-app/Podfile.lock
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   mokoSocketIo: 072c66dcab984f441fefe68db0b50f7a5215f15e
-  MultiPlatformLibrary: 820902954673ad956f3388a91fc84b2c03ea2a8d
+  MultiPlatformLibrary: 41e8d64a1458dccbcb5114c1c2d5bc0cf3948c07
   Socket.IO-Client-Swift: 1e3e3a1f09f3312a167f0d781eb2f383d477357c
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
 

--- a/sample/mpp-library/MultiPlatformLibrary.podspec
+++ b/sample/mpp-library/MultiPlatformLibrary.podspec
@@ -1,64 +1,64 @@
 Pod::Spec.new do |spec|
-    spec.name                     = 'MultiPlatformLibrary'
-    spec.version                  = '0.1.0'
-    spec.homepage                 = 'Link to a Kotlin/Native module homepage'
-    spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
-    spec.authors                  = 'IceRock Development'
-    spec.license                  = ''
-    spec.summary                  = 'Shared code between iOS and Android'
+  spec.name                     = 'MultiPlatformLibrary'
+  spec.version                  = '0.1.0'
+  spec.homepage                 = 'Link to a Kotlin/Native module homepage'
+  spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
+  spec.authors                  = 'IceRock Development'
+  spec.license                  = ''
+  spec.summary                  = 'Shared code between iOS and Android'
 
-    spec.vendored_frameworks      = "build/cocoapods/framework/#{spec.name}.framework"
-    spec.libraries                = "c++"
-    spec.module_name              = "#{spec.name}_umbrella"
+  spec.vendored_frameworks      = "build/cocoapods/framework/#{spec.name}.framework"
+  spec.libraries                = "c++"
+  spec.module_name              = "#{spec.name}_umbrella"
 
-    spec.ios.deployment_target = '11.0'
-    spec.osx.deployment_target = '10.6'
+  spec.ios.deployment_target = '11.0'
+  spec.osx.deployment_target = '10.6'
 
-    spec.pod_target_xcconfig = {
-        'KOTLIN_FRAMEWORK_BUILD_TYPE[config=*ebug]' => 'debug',
-        'KOTLIN_FRAMEWORK_BUILD_TYPE[config=*elease]' => 'release',
-        'CURENT_SDK[sdk=iphoneos*]' => 'iphoneos',
-        'CURENT_SDK[sdk=iphonesimulator*]' => 'iphonesimulator',
-        'CURENT_SDK[sdk=macosx*]' => 'macos'
-    }
+  spec.pod_target_xcconfig = {
+      'KOTLIN_FRAMEWORK_BUILD_TYPE[config=*ebug]' => 'debug',
+      'KOTLIN_FRAMEWORK_BUILD_TYPE[config=*elease]' => 'release',
+      'CURENT_SDK[sdk=iphoneos*]' => 'iphoneos',
+      'CURENT_SDK[sdk=iphonesimulator*]' => 'iphonesimulator',
+      'CURENT_SDK[sdk=macosx*]' => 'macos'
+  }
 
-    spec.script_phases = [
-        {
-            :name => 'Compile Kotlin/Native',
-            :execution_position => :before_compile,
-            :shell_path => '/bin/sh',
-            :script => <<-SCRIPT
+  spec.script_phases = [
+      {
+          :name => 'Compile Kotlin/Native',
+          :execution_position => :before_compile,
+          :shell_path => '/bin/sh',
+          :script => <<-SCRIPT
 if [ "$KOTLIN_FRAMEWORK_BUILD_TYPE" == "debug" ]; then
-  CONFIG="Debug"
+CONFIG="Debug"
 else
-  CONFIG="Release"
+CONFIG="Release"
 fi
 
 if [ "$CURENT_SDK" == "iphoneos" ]; then
-  TARGET="Ios"
-  ARCH="Arm64"
+TARGET="Ios"
+ARCH="Arm64"
 elif [ "$CURENT_SDK" == "macos" ]; then
-  TARGET="Macos"
-  if [ "$NATIVE_ARCH" == "arm64" ]; then
-    ARCH="Arm64"
-  else
-    ARCH="X64"
-  fi
+TARGET="Macos"
+if [ "$NATIVE_ARCH" == "arm64" ]; then
+  ARCH="Arm64"
 else
-  if [ "$NATIVE_ARCH" == "arm64" ]; then
-    TARGET="Ios"
-    ARCH="Arm64"
-  else
-    TARGET="Ios"
-    ARCH="X64"
-  fi
+  ARCH="X64"
+fi
+else
+if [ "$NATIVE_ARCH" == "arm64" ]; then
+  TARGET="IosSimulator"
+  ARCH="Arm64"
+else
+  TARGET="Ios"
+  ARCH="X64"
+fi
 fi
 
 MPP_PROJECT_ROOT="$SRCROOT/../../mpp-library"
 GRADLE_TASK="syncMultiPlatformLibrary${CONFIG}Framework${TARGET}${ARCH}"
 
 "$MPP_PROJECT_ROOT/../gradlew" -p "$MPP_PROJECT_ROOT" "$GRADLE_TASK"
-            SCRIPT
-        }
-    ]
+          SCRIPT
+      }
+  ]
 end

--- a/sample/mpp-library/build.gradle.kts
+++ b/sample/mpp-library/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
     jvmToolchain(11)
     androidTarget()
     ios()
+    iosSimulatorArm64()
 }
 
 dependencies {


### PR DESCRIPTION
- chore: add support for kotlin v1.9.10 and android gradle plugin v8.2.2
- podspec changes for ios arm simulator
- fix iosSimulatorArm64 run
